### PR TITLE
LDAP-96 Identify user profile by stored "dn" attribute if finding it via uid fails

### DIFF
--- a/ldap-authenticator/src/main/java/org/xwiki/contrib/ldap/LDAPProfileXClass.java
+++ b/ldap-authenticator/src/main/java/org/xwiki/contrib/ldap/LDAPProfileXClass.java
@@ -252,6 +252,7 @@ public class LDAPProfileXClass
      *
      * @param dn the LDAP DN.
      * @return the user profile containing LDAP dn.
+     * @since 9.4.6
      */
     public XWikiDocument searchDocumentByDn(String dn)
     {

--- a/ldap-authenticator/src/main/java/org/xwiki/contrib/ldap/LDAPProfileXClass.java
+++ b/ldap-authenticator/src/main/java/org/xwiki/contrib/ldap/LDAPProfileXClass.java
@@ -255,7 +255,7 @@ public class LDAPProfileXClass
      *
      * @param dn the LDAP DN.
      * @return the user profile containing LDAP dn.
-     * @since 9.4.6
+     * @since 9.5
      */
     public XWikiDocument searchDocumentByDn(String dn)
     {

--- a/ldap-authenticator/src/main/java/org/xwiki/contrib/ldap/XWikiLDAPAuthServiceImpl.java
+++ b/ldap-authenticator/src/main/java/org/xwiki/contrib/ldap/XWikiLDAPAuthServiceImpl.java
@@ -684,7 +684,6 @@ public class XWikiLDAPAuthServiceImpl extends XWikiAuthServiceImpl
             if (isNewUser) {
                 userProfile = ldapUtils.getUserProfileByDn(validXWikiUserName, ldapDn, context);
                 isNewUser = userProfile == null || userProfile.isNew();
-                LOGGER.info("PATCH: is user profile found for [{}] ? {} :: {}", ldapDn, !isNewUser, userProfile);
             }
 
             // ////////////////////////////////////////////////////////////////////

--- a/ldap-authenticator/src/main/java/org/xwiki/contrib/ldap/XWikiLDAPAuthServiceImpl.java
+++ b/ldap-authenticator/src/main/java/org/xwiki/contrib/ldap/XWikiLDAPAuthServiceImpl.java
@@ -677,10 +677,19 @@ public class XWikiLDAPAuthServiceImpl extends XWikiAuthServiceImpl
             }
 
             // ////////////////////////////////////////////////////////////////////
-            // 9. sync user
+            // 9. if not already found, search for XWiki user profile page by dn
             // ////////////////////////////////////////////////////////////////////
 
             boolean isNewUser = userProfile == null || userProfile.isNew();
+            if (isNewUser) {
+                userProfile = ldapUtils.getUserProfileByDn(validXWikiUserName, ldapDn, context);
+                isNewUser = userProfile == null || userProfile.isNew();
+                LOGGER.info("PATCH: is user profile found for [{}] ? {} :: {}", ldapDn, !isNewUser, userProfile);
+            }
+
+            // ////////////////////////////////////////////////////////////////////
+            // 10. sync user
+            // ////////////////////////////////////////////////////////////////////
 
             userProfile = syncUser(userProfile, searchAttributes, ldapDn, trimedAuthInput, ldapUtils, context);
 

--- a/ldap-authenticator/src/main/java/org/xwiki/contrib/ldap/XWikiLDAPUtils.java
+++ b/ldap-authenticator/src/main/java/org/xwiki/contrib/ldap/XWikiLDAPUtils.java
@@ -1640,7 +1640,7 @@ public class XWikiLDAPUtils
     /**
      * Look up user profile using the DN as unique identifier.
      * @see {@link #getUserProfileByUid(String, String, XWikiContext)}
-     * @since 9.4.6
+     * @since 9.5
      */
     public XWikiDocument getUserProfileByDn(String validXWikiUserName, String userId, XWikiContext context)
         throws XWikiException

--- a/ldap-authenticator/src/main/java/org/xwiki/contrib/ldap/XWikiLDAPUtils.java
+++ b/ldap-authenticator/src/main/java/org/xwiki/contrib/ldap/XWikiLDAPUtils.java
@@ -1640,6 +1640,7 @@ public class XWikiLDAPUtils
     /**
      * Look up user profile using the DN as unique identifier.
      * @see {@link #getUserProfileByUid(String, String, XWikiContext)}
+     * @since 9.4.6
      */
     public XWikiDocument getUserProfileByDn(String validXWikiUserName, String userId, XWikiContext context)
         throws XWikiException

--- a/ldap-authenticator/src/main/java/org/xwiki/contrib/ldap/XWikiLDAPUtils.java
+++ b/ldap-authenticator/src/main/java/org/xwiki/contrib/ldap/XWikiLDAPUtils.java
@@ -1634,6 +1634,22 @@ public class XWikiLDAPUtils
     public XWikiDocument getUserProfileByUid(String validXWikiUserName, String userId, XWikiContext context)
         throws XWikiException
     {
+        return getUserProfileByUniqueAttribute(validXWikiUserName, userId, false, context);
+    }
+
+    /**
+     * Look up user profile using the DN as unique identifier.
+     * @see {@link #getUserProfileByUid(String, String, XWikiContext)}
+     */
+    public XWikiDocument getUserProfileByDn(String validXWikiUserName, String userId, XWikiContext context)
+        throws XWikiException
+    {
+        return getUserProfileByUniqueAttribute(validXWikiUserName, userId, true, context);
+    }
+
+    private XWikiDocument getUserProfileByUniqueAttribute(String validXWikiUserName, String userId, boolean tryDn, XWikiContext context)
+        throws XWikiException
+    {
         LDAPProfileXClass ldapXClass = new LDAPProfileXClass(context);
 
         // Try default profile name (generally in the cache)
@@ -1646,8 +1662,8 @@ public class XWikiLDAPUtils
         }
 
         if (!userId.equalsIgnoreCase(ldapXClass.getUid(userProfile))) {
-            // Search for existing profile with provided uid
-            userProfile = ldapXClass.searchDocumentByUid(userId);
+            // Search for existing profile with provided unique attribute
+            userProfile = (tryDn) ? ldapXClass.searchDocumentByDn(userId) : ldapXClass.searchDocumentByUid(userId);
 
             // Resolve default profile patch of an uid
             if (userProfile == null && validXWikiUserName != null) {


### PR DESCRIPTION
this turned out to be a bit more code than I initially thought, as I need to drill through two helper classes to perform the query by the `dn`-attribute.

@tmortagne does this look like what you expected or do you want to see some changes?

