### PR TITLE
Add ldap service discovery to ldap-authenticator

### DIFF
--- a/ldap-authenticator/pom.xml
+++ b/ldap-authenticator/pom.xml
@@ -54,6 +54,11 @@
       <artifactId>jldap</artifactId>
       <version>2009-10-07</version>
     </dependency>
+    <dependency>
+      <groupId>dnsjava</groupId>
+      <artifactId>dnsjava</artifactId>
+      <version>3.5.0</version>
+    </dependency>
     <!-- Testing dependencies -->
     <dependency>
       <groupId>org.xwiki.commons</groupId>


### PR DESCRIPTION
This adds ldap service discovery to the ldap-authenticator plugin: When connecting to the configured ldap server, a DNS lookup is performed to check, if there are any `_ldap._tcp` SRV records for `ldapHost` (essentially treating the `ldapHost` as realm) and if so, using the one with the highest priority and weight as new `ldapHost`.

Happy to make changes so it can become a part of ldap-authenticator, e.g. introducing a parameter to turn service discovery on or off. Just let me know.