### PR TITLE
Failover discovered ldap hosts

### DIFF
--- a/ldap-authenticator/src/main/java/org/xwiki/contrib/ldap/XWikiLDAPConnection.java
+++ b/ldap-authenticator/src/main/java/org/xwiki/contrib/ldap/XWikiLDAPConnection.java
@@ -245,7 +245,7 @@ public class XWikiLDAPConnection
      * @param port the port of the server to connect to.
      * @param doServiceDiscovery if true, LDAP hosts are discovered via a SRV record lookup. If no SRV record is found,
      *            <code>ldapHost</code> is used as fallback.
-     * @param ssl true if the connection should use LDAPS
+     * @param ssl if true service discovery is performed for LDAPS.
      * @throws LDAPException error when trying to connect.
      */
     private void connect(String ldapHost, int port, boolean doServiceDiscovery, boolean ssl) throws LDAPException
@@ -286,10 +286,11 @@ public class XWikiLDAPConnection
     }
 
     /**
-     * Performs an SRV record lookup on <code>_ldap._tcp.realm</code>.
+     * Performs an SRV record lookup on <code>_ldap._tcp.realm</code> or <code>_ldaps._tcp.realm</code> if ssl is
+     * enabled.
      * 
      * @param realm the realm for which SRV records should be looked up
-     * @param ldaps true if the connection should use LDAPS
+     * @param ldaps if true, service discovery uses <code>_ldaps._tcp</code>, if false <code>_ldap._tcp</code> is used.
      * @return the SRV record with the highest priority/weight, null if no SRV record was found
      */
     private SRVRecord discoverLDAPService(String realm, boolean ldaps)


### PR DESCRIPTION
This hands over all discovered LDAP hosts to the connect method of the LDAPConnection class as a string separated list. The LDAPConnection will handle failover if the host with the highest priority and weight is unresponsive and pick the next one in the list in accordance with https://www.novell.com/documentation/developer/jldap/jldapenu/api/com/novell/ldap/LDAPConnection.html#connect(java.lang.String,%20int)