### PR TITLE
Use JNDI-DNS for DNS lookups instead of dnsjava

### DIFF
--- a/ldap-authenticator/pom.xml
+++ b/ldap-authenticator/pom.xml
@@ -54,11 +54,6 @@
       <artifactId>jldap</artifactId>
       <version>2009-10-07</version>
     </dependency>
-    <dependency>
-      <groupId>dnsjava</groupId>
-      <artifactId>dnsjava</artifactId>
-      <version>3.5.0</version>
-    </dependency>
     <!-- Testing dependencies -->
     <dependency>
       <groupId>org.xwiki.commons</groupId>


### PR DESCRIPTION
This swaps the DNS lookup via dnsjava with JNDI-DNS to address the issues raised in https://jira.xwiki.org/projects/LDAP/issues/LDAP-114