### PR TITLE
LDAP-119: LDAP search overrides connection constrains

### DIFF
--- a/ldap-authenticator/src/main/java/org/xwiki/contrib/ldap/PagedLDAPSearchResults.java
+++ b/ldap-authenticator/src/main/java/org/xwiki/contrib/ldap/PagedLDAPSearchResults.java
@@ -97,7 +97,7 @@ public class PagedLDAPSearchResults implements AutoCloseable
     private void search(byte[] cookie) throws LDAPException
     {
         LDAPPagedResultsControl control = new LDAPPagedResultsControl(this.pageSize, cookie, false);
-        LDAPSearchConstraints constraints = new LDAPSearchConstraints();
+        LDAPSearchConstraints constraints = new LDAPSearchConstraints(this.connection.getConstraints());
         constraints.setControls(control);
 
         if (LOGGER.isDebugEnabled()) {

--- a/ldap-authenticator/src/main/java/org/xwiki/contrib/ldap/XWikiLDAPConnection.java
+++ b/ldap-authenticator/src/main/java/org/xwiki/contrib/ldap/XWikiLDAPConnection.java
@@ -46,6 +46,7 @@ import org.slf4j.LoggerFactory;
 import com.novell.ldap.LDAPAttribute;
 import com.novell.ldap.LDAPAttributeSet;
 import com.novell.ldap.LDAPConnection;
+import com.novell.ldap.LDAPConstraints;
 import com.novell.ldap.LDAPDN;
 import com.novell.ldap.LDAPEntry;
 import com.novell.ldap.LDAPException;
@@ -134,6 +135,14 @@ public class XWikiLDAPConnection
     public LDAPConnection getConnection()
     {
         return this.connection;
+    }
+
+    /**
+     * @return the {@link LDAPConstraints} set for this connection.
+     */
+    public LDAPConstraints getConstraints()
+    {
+        return this.connection.getConstraints();
     }
 
     /**


### PR DESCRIPTION
* don't override the LDAP connection constraints when performing a search