### PR TITLE
LDAP-120: Allow to not set the java secure provider used in SSL connection

### DIFF
--- a/ldap-authenticator/src/main/java/org/xwiki/contrib/ldap/XWikiLDAPConfig.java
+++ b/ldap-authenticator/src/main/java/org/xwiki/contrib/ldap/XWikiLDAPConfig.java
@@ -138,11 +138,6 @@ public class XWikiLDAPConfig
      */
     private static final Logger LOGGER = LoggerFactory.getLogger(XWikiLDAPConfig.class);
 
-    /**
-     * The default secure provider to use for SSL.
-     */
-    private static final String DEFAULT_SECUREPROVIDER = "com.sun.net.ssl.internal.ssl.Provider";
-
     static {
         DEFAULT_GROUP_CLASSES.add("group".toLowerCase());
         DEFAULT_GROUP_CLASSES.add("groupOfNames".toLowerCase());
@@ -520,21 +515,24 @@ public class XWikiLDAPConfig
     }
 
     /**
-     * @return the secure provider to use for SSL.
+     * @return the secure provider to use for SSL, or {@code null} if the preregistered ones must be used.
      * @throws XWikiLDAPException error when trying to instantiate secure provider.
      * @since 9.1.1
      */
     public Provider getSecureProvider() throws XWikiLDAPException
     {
-        Provider provider;
+        Provider provider = null;
 
         ClassLoader cl = Thread.currentThread().getContextClassLoader();
-        String className = getLDAPParam("ldap_ssl.secure_provider", DEFAULT_SECUREPROVIDER);
+        // Get a specific provider only if specifically asked.
+        String className = getLDAPParam("ldap_ssl.secure_provider", null);
 
-        try {
-            provider = (java.security.Provider) cl.loadClass(className).newInstance();
-        } catch (Exception e) {
-            throw new XWikiLDAPException("Fail to load secure ssl provider.", e);
+        if (className != null) {
+            try {
+                provider = (java.security.Provider) cl.loadClass(className).newInstance();
+            } catch (Exception e) {
+                throw new XWikiLDAPException("Fail to load secure ssl provider.", e);
+            }
         }
 
         return provider;

--- a/ldap-authenticator/src/main/java/org/xwiki/contrib/ldap/XWikiLDAPConnection.java
+++ b/ldap-authenticator/src/main/java/org/xwiki/contrib/ldap/XWikiLDAPConnection.java
@@ -20,6 +20,7 @@
 package org.xwiki.contrib.ldap;
 
 import java.io.UnsupportedEncodingException;
+import java.security.Provider;
 import java.security.Security;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -195,8 +196,12 @@ public class XWikiLDAPConnection
 
         try {
             if (ssl) {
-                // Dynamically set JSSE as a security provider
-                Security.addProvider(this.configuration.getSecureProvider());
+                // The security providers are preregistered and used depending on the context, so there is no need to
+                // set one. Dynamically set it only if a specific provider is requested.
+                Provider secureProvider = this.configuration.getSecureProvider();
+                if (secureProvider != null) {
+                    Security.addProvider(secureProvider);
+                }
 
                 if (pathToKeys != null && pathToKeys.length() > 0) {
                     // Dynamically set the property that JSSE uses to identify


### PR DESCRIPTION
* don't set a default value for the secure provider when none is specifically requested