### PR TITLE
LDAP-154: User cleanup disables all users when the connection to the …

### DIFF
--- a/ldap-authenticator/src/main/java/org/xwiki/contrib/ldap/XWikiLDAPConnection.java
+++ b/ldap-authenticator/src/main/java/org/xwiki/contrib/ldap/XWikiLDAPConnection.java
@@ -515,7 +515,8 @@ public class XWikiLDAPConnection
      *            <li>SCOPE_ONE - searches only entries under the base DN
      *            <li>SCOPE_SUB - searches the base DN and all entries within its subtree
      *            </ul>
-     * @return the found LDAP attributes.
+     * @return the found LDAP attributes. If nothing was found, an empty list is returned. If an exception is thrown,
+     *     null is returned.
      */
     public List<XWikiLDAPSearchAttribute> searchLDAP(String baseDN, String filter, String[] attr, int ldapScope)
     {

--- a/ldap-authenticator/src/main/java/org/xwiki/contrib/ldap/XWikiLDAPConnection.java
+++ b/ldap-authenticator/src/main/java/org/xwiki/contrib/ldap/XWikiLDAPConnection.java
@@ -24,6 +24,7 @@ import java.security.Provider;
 import java.security.Security;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Enumeration;
 import java.util.HashSet;
 import java.util.Hashtable;
@@ -523,7 +524,7 @@ public class XWikiLDAPConnection
         // filter return all attributes return attrs and values time out value
         try (PagedLDAPSearchResults searchResults = searchPaginated(baseDN, ldapScope, filter, attr, false)) {
             if (!searchResults.hasMore()) {
-                return null;
+                return Collections.emptyList();
             }
 
             LDAPEntry nextEntry = searchResults.next();

--- a/ldap-authenticator/src/main/java/org/xwiki/contrib/ldap/XWikiLDAPUtils.java
+++ b/ldap-authenticator/src/main/java/org/xwiki/contrib/ldap/XWikiLDAPUtils.java
@@ -1109,7 +1109,7 @@ public class XWikiLDAPUtils
                     getConnection().searchLDAP(ldapDn, null, getAttributeNameTable(context), LDAPConnection.SCOPE_BASE);
             }
 
-            if (attributes == null) {
+            if (attributes == null || attributes.isEmpty()) {
                 LOGGER.error("Can't find any attributes for user [{}]", ldapDn);
             }
 

--- a/ldap-user-cleanup/src/main/resources/Scheduler/LDAP/OldUserCleanupJob.xml
+++ b/ldap-user-cleanup/src/main/resources/Scheduler/LDAP/OldUserCleanupJob.xml
@@ -874,7 +874,7 @@ def getOrDefault(object, attribute, defaultValue) {
 }
 
 def shouldDelete(userDn, userId, ldapConfig, config, connector, ldapUtils, it, logger) {
-  def userObj = null;
+  def userObj = [];
   if (userDn == null || userDn.isEmpty()) {
     logger.debug("DN of user [{}] is empty.", it);
     // Setting the userDn to null in case it is an empty string, otherwise the removeExcludedGroups checks would fail.
@@ -883,7 +883,10 @@ def shouldDelete(userDn, userId, ldapConfig, config, connector, ldapUtils, it, l
     logger.debug("lookup by DN for [{}]", userDn);
     userObj = connector.searchLDAP(userDn, '(objectClass=*)', null, 0);
   }
-
+  if (userObj == null) {
+    logger.warn("There was an error when trying to search for the user [{}]. The user won't be disabled/deleted.");
+    return false;
+  }
   if (userObj == null || userObj.isEmpty()) {
     def searchQuery = ldapConfig.getLDAPParam("ldap_user_search_fmt", "({0}={1})");
     logger.debug("DN lookup failed; search instead for uid=[{}] with [{}]", userId, searchQuery);
@@ -891,7 +894,11 @@ def shouldDelete(userDn, userId, ldapConfig, config, connector, ldapUtils, it, l
     userObj = ldapUtils.searchUserAttributesByUid(userId, null);
   }
 
-  if (userObj == null || userObj.isEmpty()) {
+  if (userObj == null) {
+    logger.warn("There was an error when trying to search for the user [{}]. The user won't be disabled/deleted.");
+    return false;
+  }
+  else if (userObj.isEmpty()) {
     return true;
   }
 


### PR DESCRIPTION
…server fails

Fixes: https://jira.xwiki.org/projects/LDAP/issues/LDAP-154

`XWikiLDAPConnection#searchLDAP` returns `null` if some exception was thrown but also when the search does not find anything.

The user cleanup job assumes that the user does not exist if `searchLDAP` returns `null`. In the case some exception was thrown, the users will be marked for removal even if they exist/are not disabled.

In order to address this, the `searchLDAP` function return `null` only if some exception was thrown. If the search did not find anything, an empty list is returned.