### PR TITLE
LDAP-166: Can't authenticate if ldap user has attribute with length g…

### DIFF
--- a/ldap-authenticator/src/main/java/org/xwiki/contrib/ldap/XWikiLDAPUtils.java
+++ b/ldap-authenticator/src/main/java/org/xwiki/contrib/ldap/XWikiLDAPUtils.java
@@ -1449,7 +1449,7 @@ public class XWikiLDAPUtils
                     map.put(name, mapValue);
                 }
                 ((List) mapValue).add(value);
-            } else if (pclass instanceof StringClass && !(pclass instanceof TextAreaClass)) {
+            } else if (pclass instanceof StringClass && !(pclass instanceof TextAreaClass) && value.length() > 768) {
                 LOGGER.warn(
                     "The value of the attribute [{}] is longer than the supported size for a xwiki string property. "
                         + "The imported value was trimmed.",

--- a/ldap-authenticator/src/main/java/org/xwiki/contrib/ldap/XWikiLDAPUtils.java
+++ b/ldap-authenticator/src/main/java/org/xwiki/contrib/ldap/XWikiLDAPUtils.java
@@ -68,6 +68,8 @@ import com.xpn.xwiki.objects.BaseObject;
 import com.xpn.xwiki.objects.classes.BaseClass;
 import com.xpn.xwiki.objects.classes.ListClass;
 import com.xpn.xwiki.objects.classes.PropertyClass;
+import com.xpn.xwiki.objects.classes.StringClass;
+import com.xpn.xwiki.objects.classes.TextAreaClass;
 import com.xpn.xwiki.web.Utils;
 
 /**
@@ -1447,6 +1449,12 @@ public class XWikiLDAPUtils
                     map.put(name, mapValue);
                 }
                 ((List) mapValue).add(value);
+            } else if (pclass instanceof StringClass && !(pclass instanceof TextAreaClass)) {
+                LOGGER.warn(
+                    "The value of the attribute [{}] is longer than the supported size for a xwiki string property. "
+                        + "The imported value was trimmed.",
+                    name);
+                map.put(name, value.substring(0, 768));
             } else {
                 map.put(name, value);
             }


### PR DESCRIPTION
…reater than 768 characters

Fixes: jira.xwiki.org/browse/LDAP-166

I don't like the idea of trimming the value like that but im not sure of what other solution we might have. Any thoughts, @tmortagne ?